### PR TITLE
Run test in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,5 +16,9 @@ jobs:
           cache: yarn
       - name: Install yarn
         run: npm install --global yarn
+      - name: Install node dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run vitest
+        run: yarn run vitest
       - name: Run CI
         run: mvn --batch-mode clean verify

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,5 +20,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Run vitest
         run: yarn run vitest
+      - name: Run karma tests
+        run: yarn run karma-test
       - name: Run CI
         run: mvn --batch-mode clean verify


### PR DESCRIPTION
## Description
#516 
Run Vitest and karma tests during CI.
Vitest is used for testing Angular2+ components, and for unit testing native Typescript objects.
Legacy content (AngularJS files) has been tested with karma-jasmine.

## Checklists
No relevant checklist here
