### PR TITLE
Fix constantly expanding uPlot graph

### DIFF
--- a/src/app/objects/output/format/uPlot/uPlotPlugin/configuration/resizeListener/resizeListenerImpl.ts
+++ b/src/app/objects/output/format/uPlot/uPlotPlugin/configuration/resizeListener/resizeListenerImpl.ts
@@ -75,11 +75,11 @@ export class ResizeListenerImpl implements ResizeListener {
 
   registerToElement(graph: uPlot, el:Element):void {
     this.disconnectResizeObserver();
+    let width = 0;
     this._resizeObserver = new ResizeObserver((entries) => {
       const entry = entries.pop();
       if(entry){
         const newWidth = entry.contentRect.width;
-        let width = 0;
         if(newWidth !== width){
           window.requestAnimationFrame(() => {
             width = newWidth;


### PR DESCRIPTION
## Description
Width variable was changed inside a callback function in PR:
https://github.com/teragrep/ajs_01/pull/532/changes

this caused bug where uPlot graph was constantly expanding due to the resizeObserver callback always asserting that the graph is not sized properly

